### PR TITLE
feat(import): Import YouTube playlist from Nightbot

### DIFF
--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -117,9 +117,11 @@ const PageSettingsModulesImportNightbot: React.FC<{
       } else if (error.response.status >= 500 && error.response.status < 600) {
         enqueueSnackbar('Remote server error.', { variant: 'error' });
         console.error(`Error === ${error.response.status}`);
+        return acc
       } else {
         enqueueSnackbar('Remote server error.', { variant: 'error' });
         console.error(`Error !== 429 or 5XX: ${error.response.status}`);
+        return acc
       }
     }
   };

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -91,7 +91,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
     playlist: PlaylistItem[];
   };
 
-  const fetchPlaylist = async (acc: PlaylistItemTrack[], offset: number): Promise<T> => {
+  const fetchPlaylist = async (acc: PlaylistItemTrack[] = [], offset = 0): Promise<T> => {
     const url = 'https://api.nightbot.tv/1/song_requests/playlist?limit=100&offset=';
     let maxRetries = 3;
 
@@ -125,7 +125,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
   };
 
   const importPlaylist = async () => {
-    const videos: PlaylistItemTrack[] = await fetchPlaylist([], 0);
+    const videos: PlaylistItemTrack[] = await fetchPlaylist();
     const ytVideos = videos.filter((track) => {
       track.provider === 'youtube';
     });
@@ -178,8 +178,8 @@ const PageSettingsModulesImportNightbot: React.FC<{
             </InputAdornment>,
           }}
         />
-        <Stack direction='row-reverse'>
-          <Button color='primary' variant='contained' disabled={user === 'Not Authorized'} onClick={importPlaylist}>Import</Button>
+        <Stack direction='row'>
+          <Button color='primary' variant='contained' disabled={user === 'Not Authorized'} onClick={importPlaylist}>Import playlist</Button>
         </Stack>
 
       </Paper>

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -1,5 +1,5 @@
 import {
-  Box, Button, CircularProgress, Container, InputAdornment, Paper, TextField, Typography,
+  Box, Button, CircularProgress, InputAdornment, Paper, Stack, TextField, Typography,
 } from '@mui/material';
 import axios from 'axios';
 import { useSnackbar } from 'notistack';
@@ -66,8 +66,6 @@ const PageSettingsModulesImportNightbot: React.FC<{
     enqueueSnackbar('User access revoked.', { variant: 'success' });
   }, [ enqueueSnackbar ]);
 
-  const [playlist, setPlaylist] = React.useState([]);
-
   type PlaylistItemTrack = {
     providerId: string;
     provider: string;
@@ -124,9 +122,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
         },
       );
 
-      const response = await ax.get('https://api.nightbot.tv/1/song_requests/playlist?limit=100&offset='+offset, {
-        headers: { Authorization: 'Bearer ' + accessToken },
-      });
+      const response = await ax.get('https://api.nightbot.tv/1/song_requests/playlist?limit=100&offset='+offset, { headers: { Authorization: 'Bearer ' + accessToken } });
 
       const data: PlaylistPage = response.data;
       const tracks = data.playlist.map((e) => e.track);
@@ -139,10 +135,8 @@ const PageSettingsModulesImportNightbot: React.FC<{
       return await fetchResource(acc, offset + 100);
     };
 
-    const pl = await fetchResource([], 0);
-    setPlaylist(pl);
+    return await fetchResource([], 0);
 
-    return pl;
   };
 
   const importPlaylist = async () => {
@@ -179,7 +173,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
   };
 
   return (
-    <Box ref={ref} id="nightbot">
+    <Box ref={ref} id='nightbot'>
       <Typography variant='h2' sx={{ pb: 2 }}>Nightbot</Typography>
       <Paper elevation={1} sx={{ p: 1 }}>
         {userLoadInProgress}
@@ -190,19 +184,16 @@ const PageSettingsModulesImportNightbot: React.FC<{
           value={userLoadInProgress ? 'Loading user data...' : user}
           label={translate('integrations.lastfm.settings.username')}
           InputProps={{
-            startAdornment: userLoadInProgress && <InputAdornment position="start"><CircularProgress size={20}/></InputAdornment>,
-            endAdornment:   <InputAdornment position="end">
-              { user !== 'Not Authorized'
-                ? <Button color="error" variant="contained" onClick={revoke}>Revoke</Button>
-                : <Button color="success" variant="contained" onClick={authorize}>Authorize</Button>
-              }
+            endAdornment: <InputAdornment position='end'> { user !== 'Not Authorized'
+              ? <Button color='error' variant='contained' onClick={revoke}>Revoke</Button>
+              : <Button color='success' variant='contained' onClick={authorize}>Authorize</Button>
+            }
             </InputAdornment>,
           }}
         />
-        <Container>
-          <Button color="primary" variant="contained" disabled={user === 'Not Authorized'} onClick={importPlaylist}>Import</Button>
-          <pre>{JSON.stringify(playlist, null, 2)}</pre>
-        </Container>
+        <Stack direction='row-reverse'>
+          <Button color='primary' variant='contained' disabled={user === 'Not Authorized'} onClick={importPlaylist}>Import</Button>
+        </Stack>
 
       </Paper>
     </Box>

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -93,7 +93,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
 
   const sleep = async (ms: number) => {
     await new Promise((resolve) => setTimeout(resolve, ms));
-  }
+  };
 
   const fetchPlaylistPage = async (offset: number): Promise<PlaylistResponse> => {
     const url = 'https://api.nightbot.tv/1/song_requests/playlist';
@@ -117,7 +117,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
     console.error('Error fetching playlist page after multiple retries.');
     enqueueSnackbar('Remote server error.', { variant: 'error' });
     throw new Error('Failed to fetch playlist after multiple retries.');
-  }
+  };
 
   const fetchTracks = async (tracks: Track[] = [], offset = 0): Promise<Track[]> => {
     try {
@@ -136,27 +136,31 @@ const PageSettingsModulesImportNightbot: React.FC<{
 
   const importPlaylist = async () => {
     const tracks = await fetchTracks();
-    const ytVideos = tracks.filter(track => track.provider === 'youtube');
+    const ytVideos = tracks.filter((track) => track.provider === 'youtube');
     let failCount = 0;
     for (const track of ytVideos) {
-      await new Promise((resolve, reject) => {
-        getSocket('/systems/songs').emit(
-          'import.video',
-          {
-            playlist:  track.providerId,
-            forcedTag: 'nightbot-import',
-          },
-          (err) => {
-            if (err) {
-              failCount += 1;
-              console.error('error: ', track.url);
-              reject(err);
-            } else {
-              resolve('resolved');
-            }
-          },
-        );
-      });
+      try {
+        await new Promise((resolve, reject) => {
+          getSocket('/systems/songs').emit(
+            'import.video',
+            {
+              playlist:  track.providerId,
+              forcedTag: 'nightbot-import',
+            },
+            (err) => {
+              if (err) {
+                failCount += 1;
+                console.error('error: ', track.url);
+                reject(err);
+              } else {
+                resolve('resolved');
+              }
+            },
+          );
+        });
+      } catch (error) {
+        console.log('ERROR DURING IMPORT: ', error);
+      }
     }
     if (failCount > 0) {
       enqueueSnackbar(`${failCount} videos failed to import.`, { variant: 'info' });

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -159,7 +159,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
           );
         });
       } catch (error) {
-        console.log('ERROR DURING IMPORT: ', error);
+        console.error('ERROR DURING IMPORT: ', error);
       }
     }
     if (failCount > 0) {

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -91,11 +91,11 @@ const PageSettingsModulesImportNightbot: React.FC<{
     playlist: PlaylistItem[];
   };
 
-  async function sleep(ms: number) {
+  const sleep = async (ms: number) => {
     await new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  async function fetchPlaylistPage(offset: number): Promise<PlaylistResponse> {
+  const fetchPlaylistPage = async (offset: number): Promise<PlaylistResponse> => {
     const url = 'https://api.nightbot.tv/1/song_requests/playlist';
     const delay = 10 ** 4 * 6;
     const delaySeconds = delay / 10 ** 3;


### PR DESCRIPTION
This commit implements the first pass at importing the playlist managed by Nightbot. In the code, I have left a few comments to make note of some undercooked solutions.

I tried doing this with simple `React.useState()` but you may find that this approach is too naive. For now, I do it this way to make it easier to output the playlist resource into a text field. It's something like a `console.log(playlist)` with extra steps.

Setting aside code style, my next step is to figure out how to convert the tracks from Nightbot into tracks for SogeBot. Do you have some pointers to where I could start gluing that together? 

In [playlist.tsx](https://github.com/sogebot/sogebot.dev/blob/0f587695c77d19210a144ccbb3058a21f43167b0/ui.admin-mui/src/routes/manage/youtube/playlist.tsx#L263) I see a handler for adding songs to the playlist, but I'm not sure if that's the right inspiration I should find (copy and paste lmao).

Also, existing SogeBot users may discover this feature and wish to import their old Nightbot playlist. There is some potential for such an import to clobber an existing playlist, I think by modifying `createdAt` or `updatedAt` values or duplicating items. I'm not sure how to mitigate that yet.
