### PR TITLE
Import Nightbot Custom Commands & Timers

### DIFF
--- a/services/credentials/authenticators/nightbot.go
+++ b/services/credentials/authenticators/nightbot.go
@@ -27,6 +27,7 @@ func Nightbot(w http.ResponseWriter, r *http.Request) {
 	if code == "" {
 		scopes := []string{
 			"song_requests_playlist",
+			"commands",
 		}
 		q := url.Values{}
 		q.Add("client_id", NIGHTBOT_CLIENTID)

--- a/services/credentials/authenticators/nightbot.go
+++ b/services/credentials/authenticators/nightbot.go
@@ -28,6 +28,7 @@ func Nightbot(w http.ResponseWriter, r *http.Request) {
 		scopes := []string{
 			"song_requests_playlist",
 			"commands",
+			"timers",
 		}
 		q := url.Values{}
 		q.Add("client_id", NIGHTBOT_CLIENTID)

--- a/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
@@ -97,7 +97,7 @@ export const importCustomCommands = async (accessToken: string | null) => {
   for (const command of commands) {
     try {
       const convertedCommand = {
-        id:                     command._id,
+        id:                     crypto.randomUUID(),
         command:                command.name,
         enabled:                true,
         visible:                true,
@@ -105,7 +105,7 @@ export const importCustomCommands = async (accessToken: string | null) => {
         areResponsesRandomized: false,
         responses:              [
           {
-            id:             command._id,
+            id:             crypto.randomUUID(),
             order:          0,
             response:       command.message,
             stopIfExecuted: false,

--- a/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
@@ -260,9 +260,7 @@ export const importCustomCommands = async (accessToken: string | null) => {
   let failCount = 0;
   for (const command of commands) {
     try {
-      command.name.startsWith('!')
-        ? postCommand(command)
-        : postKeyword(command);
+      command.name.startsWith('!') ? postCommand(command) : postKeyword(command);
     } catch (error: any) {
       failCount++;
     }

--- a/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
@@ -97,7 +97,6 @@ export const importCustomCommands = async (accessToken: string | null) => {
   for (const command of commands) {
     try {
       const convertedCommand = {
-        id:                     crypto.randomUUID(),
         command:                command.name,
         enabled:                true,
         visible:                true,
@@ -105,7 +104,6 @@ export const importCustomCommands = async (accessToken: string | null) => {
         areResponsesRandomized: false,
         responses:              [
           {
-            id:             crypto.randomUUID(),
             order:          0,
             response:       command.message,
             stopIfExecuted: false,

--- a/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
@@ -1,0 +1,220 @@
+import axios from 'axios';
+import { enqueueSnackbar } from 'notistack';
+
+import { getSocket } from '../../../helpers/socket';
+
+type UserLevel =
+  | 'admin'
+  | 'owner'
+  | 'moderator'
+  | 'twitch_vip'
+  | 'regular'
+  | 'subscriber'
+  | 'everyone';
+
+type CustomCommand = {
+  _id:       string;
+  createdAt: string; // timestamp date
+  updatedAt: string; // timestamp date
+  name:      string;
+  message:   string;
+  coolDown:  number;
+  count:     number;
+  userLevel: UserLevel;
+};
+
+type CustomCommandsResponse = {
+  _total:   number;
+  status:   number;
+  commands: CustomCommand[];
+};
+
+export const sleep = async (ms: number) => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const fetchWithRetries = async (
+  url: string,
+  headers: { Authorization: string },
+  retries = 3,
+  delay = 6 * 10e4 // 60_000ms
+) => {
+  const delaySeconds = delay / 10e3;
+  while (retries-- > 0) {
+    try {
+      const response = await axios.get(url, { headers });
+      return response.data;
+    } catch (error: any) {
+      console.info(`Retrying after ${delaySeconds} seconds.`);
+      await sleep(delay);
+    }
+  }
+};
+
+const fetchCustomCommandsPage = async (
+  accessToken: string | null
+): Promise<CustomCommandsResponse> => {
+  const url = 'https://api.nightbot.tv/1/commands';
+  try {
+    const page = fetchWithRetries(url, {
+      Authorization: 'Bearer ' + accessToken,
+    });
+    return page;
+  } catch {
+    console.error('Error fetching commands after multiple retries.');
+    enqueueSnackbar('Remote server error.', { variant: 'error' });
+    throw new Error('Failed to fetch commands after multiple retries.');
+  }
+};
+
+export const fetchCustomCommands = async (
+  accessToken: string | null
+): Promise<CustomCommand[]> => {
+  try {
+    const page = await fetchCustomCommandsPage(accessToken);
+    return page.commands;
+  } catch (error: any) {
+    console.error('Error fetching commands.');
+    enqueueSnackbar('Remote server error.', { variant: 'error' });
+    throw new Error('Failed to fetch commands.');
+  }
+};
+
+export const importCustomCommands = async (accessToken: string | null) => {
+  const commands = await fetchCustomCommands(accessToken);
+  let failCount = 0;
+  for (const command of commands) {
+    try {
+      await new Promise((resolve, reject) => {
+        getSocket('/systems/songs').emit(
+          'import.video',
+          {
+            playlist:  '!nb_' + command.name,
+            forcedTag: 'nightbot-import',
+          },
+          (err) => {
+            if (err) {
+              failCount += 1;
+              console.error('error: ', command.name);
+              reject(err);
+            } else {
+              resolve('resolved');
+            }
+          }
+        );
+      });
+    } catch (error) {
+      console.error('ERROR DURING COMMANDS IMPORT: ', error);
+    }
+  }
+  if (failCount > 0) {
+    enqueueSnackbar(`${failCount} videos failed to import.`, {
+      variant: 'info',
+    });
+  }
+  enqueueSnackbar('Commands import completed.', { variant: 'success' });
+};
+
+type Command = {
+  providerId: string;
+  provider:   string;
+  duration:   number;
+  title:      string;
+  artist:     string;
+  url:        string;
+};
+
+type PlaylistItem = {
+  track:     Command;
+  _id:       string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type PlaylistResponse = {
+  status:   number;
+  _sort:    { date: 'asc' | 'desc' };
+  _limit:   number;
+  _offset:  number;
+  _total:   number;
+  playlist: PlaylistItem[];
+};
+
+const fetchPlaylistPage = async (offset: number, accessToken: string | null): Promise<PlaylistResponse> => {
+  const url = 'https://api.nightbot.tv/1/song_requests/playlist';
+  const delay = 10 ** 4 * 6;
+  const delaySeconds = delay / 10 ** 3;
+  for (let retries = 3; retries > 0; retries--) {
+    try {
+      const response = await axios.get(url, {
+        params: {
+          limit:  100,
+          offset: offset,
+        },
+        headers: { Authorization: 'Bearer ' + accessToken },
+      });
+      return response.data;
+    } catch (error: any) {
+      console.info(`Retrying after ${delaySeconds} seconds.`);
+      await sleep(delay);
+    }
+  }
+  console.error('Error fetching playlist page after multiple retries.');
+  enqueueSnackbar('Remote server error.', { variant: 'error' });
+  throw new Error('Failed to fetch playlist after multiple retries.');
+};
+
+const fetchTracks = async (
+  accessToken: string | null,
+  tracks: Command[] = [],
+  offset = 0
+): Promise<Command[]> => {
+  try {
+    const page = await fetchPlaylistPage(offset, accessToken);
+    const mergedTracks = tracks.concat(page.playlist.map((t) => t.track));
+    if (mergedTracks.length < page._total) {
+      await fetchTracks( accessToken, mergedTracks, offset + 100,);
+    }
+    return mergedTracks;
+  } catch (error: any) {
+    console.error('Error fetching playlist.');
+    enqueueSnackbar('Remote server error.', { variant: 'error' });
+    throw new Error('Failed to fetch playlist.');
+  }
+};
+
+export const importPlaylist = async (accessToken: string | null) => {
+  const tracks = await fetchTracks(accessToken);
+  const ytVideos = tracks.filter((track) => track.provider === 'youtube');
+  let failCount = 0;
+  for (const track of ytVideos) {
+    try {
+      await new Promise((resolve, reject) => {
+        getSocket('/systems/songs').emit(
+          'import.video',
+          {
+            playlist:  track.providerId,
+            forcedTag: 'nightbot-import',
+          },
+          (err) => {
+            if (err) {
+              failCount += 1;
+              console.error('error: ', track.url);
+              reject(err);
+            } else {
+              resolve('resolved');
+            }
+          }
+        );
+      });
+    } catch (error) {
+      console.error('ERROR DURING IMPORT: ', error);
+    }
+  }
+  if (failCount > 0) {
+    enqueueSnackbar(`${failCount} videos failed to import.`, {
+      variant: 'info',
+    });
+  }
+  enqueueSnackbar('Playlist import completed.', { variant: 'success' });
+};

--- a/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
@@ -5,6 +5,31 @@ import { enqueueSnackbar } from 'notistack';
 import getAccessToken from '../../../getAccessToken';
 import { getSocket } from '../../../helpers/socket';
 
+type Track = {
+  providerId: string;
+  provider:   string;
+  duration:   number;
+  title:      string;
+  artist:     string;
+  url:        string;
+};
+
+type PlaylistItem = {
+  track:     Track;
+  _id:       string;
+  createdAt: string; // timestamp date
+  updatedAt: string; // timestamp date
+};
+
+type PlaylistResponse = {
+  status:   number;
+  _sort:    { date: 'asc' | 'desc' };
+  _limit:   number;
+  _offset:  number;
+  _total:   number;
+  playlist: PlaylistItem[];
+};
+
 type UserLevel =
   | 'admin'
   | 'owner'
@@ -31,6 +56,16 @@ type CustomCommandsResponse = {
   commands: CustomCommand[];
 };
 
+const permissions = new Map([
+  ['admin', defaultPermissions.CASTERS],
+  ['owner', defaultPermissions.CASTERS],
+  ['moderator', defaultPermissions.MODERATORS],
+  ['twitch_vip', defaultPermissions.VIP],
+  ['regular', defaultPermissions.SUBSCRIBERS],
+  ['subscriber', defaultPermissions.SUBSCRIBERS],
+  ['everyone', defaultPermissions.VIEWERS],
+]);
+
 export const sleep = async (ms: number) => {
   await new Promise((resolve) => setTimeout(resolve, ms));
 };
@@ -51,152 +86,6 @@ const fetchWithRetries = async (
       await sleep(delay);
     }
   }
-};
-
-const fetchCustomCommandsPage = async (
-  accessToken: string | null
-): Promise<CustomCommandsResponse> => {
-  const url = 'https://api.nightbot.tv/1/commands';
-  try {
-    const page = fetchWithRetries(url, {
-      headers: { Authorization: 'Bearer ' + accessToken },
-    });
-    return page;
-  } catch {
-    console.error('Error fetching commands after multiple retries.');
-    enqueueSnackbar('Remote server error.', { variant: 'error' });
-    throw new Error('Failed to fetch commands after multiple retries.');
-  }
-};
-
-export const fetchCustomCommands = async (
-  accessToken: string | null
-): Promise<CustomCommand[]> => {
-  try {
-    const page = await fetchCustomCommandsPage(accessToken);
-    return page.commands;
-  } catch (error: any) {
-    console.error('Error fetching commands.');
-    enqueueSnackbar('Remote server error.', { variant: 'error' });
-    throw new Error('Failed to fetch commands.');
-  }
-};
-
-const permissionsMap = new Map([
-  ['admin', defaultPermissions.CASTERS],
-  ['owner', defaultPermissions.CASTERS],
-  ['moderator', defaultPermissions.MODERATORS],
-  ['twitch_vip', defaultPermissions.VIP],
-  ['regular', defaultPermissions.SUBSCRIBERS],
-  ['subscriber', defaultPermissions.SUBSCRIBERS],
-  ['everyone', defaultPermissions.VIEWERS],
-]);
-
-const postKeyword = async (command: CustomCommand) => {
-  const convertedKeyword = {
-    keyword:   command.name,
-    enabled:   true,
-    group:     'nightbot-import',
-    responses: [
-      {
-        order:          0,
-        response:       command.message,
-        stopIfExecuted: false,
-        filter:         '',
-        permission:     permissionsMap.get(command.userLevel),
-      },
-    ],
-  };
-  let failCount = 0;
-  try {
-    await axios.post(
-      `${JSON.parse(localStorage.server)}/api/systems/keywords`,
-      convertedKeyword,
-      { headers: { authorization: `Bearer ${getAccessToken()}` } }
-    );
-  } catch (error: any) {
-    failCount += 1;
-    console.error(
-      'ERROR DURING KEYWORDS IMPORT: ',
-      error.response.data.errors
-    );
-  }
-  if (failCount > 0) {
-    enqueueSnackbar(`${failCount} commands failed to import.`, {
-      variant: 'info',
-    });
-  }
-};
-
-const postCommand = async (command: CustomCommand) => {
-  const convertedCommand = {
-    command:                command.name,
-    enabled:                true,
-    visible:                true,
-    group:                  'nightbot-import',
-    areResponsesRandomized: false,
-    responses:              [
-      {
-        order:          0,
-        response:       command.message,
-        stopIfExecuted: false,
-        permission:     permissionsMap.get(command.userLevel),
-        filter:         '',
-      },
-    ],
-  };
-  let failCount = 0;
-  try {
-    await axios.post(
-      `${JSON.parse(localStorage.server)}/api/systems/customcommands`,
-      convertedCommand,
-      { headers: { authorization: `Bearer ${getAccessToken()}` } }
-    );
-  } catch (error: any) {
-    failCount += 1;
-    console.error(
-      'ERROR DURING COMMANDS IMPORT: ',
-      error.response.data.errors
-    );
-  }
-  if (failCount > 0) {
-    enqueueSnackbar(`${failCount} commands failed to import.`, {
-      variant: 'info',
-    });
-  }
-};
-
-export const importCustomCommands = async (accessToken: string | null) => {
-  const commands = await fetchCustomCommands(accessToken);
-  commands.forEach((command) =>
-    command.name.startsWith('!') ? postCommand(command) : postKeyword(command)
-  );
-  enqueueSnackbar('Commands import completed.', { variant: 'success' });
-};
-
-type Track = {
-  providerId: string;
-  provider:   string;
-  duration:   number;
-  title:      string;
-  artist:     string;
-  url:        string;
-};
-
-type PlaylistItem = {
-  track:     Track;
-  _id:       string;
-  createdAt: string; // timestamp date
-  updatedAt: string; // timestamp date
-};
-
-type PlaylistResponse = {
-  status:   number;
-  _sort:    { date: 'asc' | 'desc' };
-  _limit:   number;
-  _offset:  number;
-  _total:   number;
-  playlist: PlaylistItem[];
 };
 
 const fetchPlaylistPage = async (
@@ -228,15 +117,33 @@ const fetchTracks = async (
   try {
     const page = await fetchPlaylistPage(offset, accessToken);
     const mergedTracks = tracks.concat(page.playlist.map((t) => t.track));
-    if (mergedTracks.length < page._total) {
-      await fetchTracks(accessToken, mergedTracks, offset + 100);
-    }
-    return mergedTracks;
-  } catch (error: any) {
+    return mergedTracks.length < page._total
+      ? await fetchTracks(accessToken, mergedTracks, offset + 100)
+      : mergedTracks;
+  } catch {
     console.error('Error fetching playlist.');
     enqueueSnackbar('Remote server error.', { variant: 'error' });
     throw new Error('Failed to fetch playlist.');
   }
+};
+
+const postTrack = async (track: Track) => {
+  await new Promise((resolve, reject) => {
+    getSocket('/systems/songs').emit(
+      'import.video',
+      {
+        playlist:  track.providerId,
+        forcedTag: 'nightbot-import',
+      },
+      (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve('resolved');
+        }
+      }
+    );
+  });
 };
 
 export const importPlaylist = async (accessToken: string | null) => {
@@ -245,26 +152,10 @@ export const importPlaylist = async (accessToken: string | null) => {
   let failCount = 0;
   for (const track of ytVideos) {
     try {
-      await new Promise((resolve, reject) => {
-        getSocket('/systems/songs').emit(
-          'import.video',
-          {
-            playlist:  track.providerId,
-            forcedTag: 'nightbot-import',
-          },
-          (err) => {
-            if (err) {
-              failCount += 1;
-              console.error('error: ', track.url);
-              reject(err);
-            } else {
-              resolve('resolved');
-            }
-          }
-        );
-      });
-    } catch (error) {
-      console.error('ERROR DURING IMPORT: ', error);
+      await postTrack(track);
+    } catch {
+      console.error('error: ', track.url);
+      failCount++;
     }
   }
   if (failCount > 0) {
@@ -273,4 +164,114 @@ export const importPlaylist = async (accessToken: string | null) => {
     });
   }
   enqueueSnackbar('Playlist import completed.', { variant: 'success' });
+};
+
+const fetchCustomCommandsPage = async (
+  accessToken: string | null
+): Promise<CustomCommandsResponse> => {
+  const url = 'https://api.nightbot.tv/1/commands';
+  try {
+    const page = fetchWithRetries(url, {
+      headers: { Authorization: 'Bearer ' + accessToken },
+    });
+    return page;
+  } catch {
+    console.error('Error fetching commands after multiple retries.');
+    enqueueSnackbar('Remote server error.', { variant: 'error' });
+    throw new Error('Failed to fetch commands after multiple retries.');
+  }
+};
+
+export const fetchCustomCommands = async (
+  accessToken: string | null
+): Promise<CustomCommand[]> => {
+  try {
+    const page = await fetchCustomCommandsPage(accessToken);
+    return page.commands;
+  } catch (error: any) {
+    console.error('Error fetching commands.');
+    enqueueSnackbar('Remote server error.', { variant: 'error' });
+    throw new Error('Failed to fetch commands.');
+  }
+};
+
+const postKeyword = async (keyword: CustomCommand) => {
+  const convertedKeyword = {
+    keyword:   keyword.name,
+    enabled:   true,
+    group:     'nightbot-import',
+    responses: [
+      {
+        order:          0,
+        response:       keyword.message,
+        stopIfExecuted: false,
+        filter:         '',
+        permission:     permissions.get(keyword.userLevel),
+      },
+    ],
+  };
+  try {
+    await axios.post(
+      `${JSON.parse(localStorage.server)}/api/systems/keywords`,
+      convertedKeyword,
+      { headers: { authorization: `Bearer ${getAccessToken()}` } }
+    );
+  } catch (error: any) {
+    console.error(
+      'ERROR DURING KEYWORDS IMPORT: ',
+      error.response.data.errors
+    );
+  }
+};
+
+const postCommand = async (command: CustomCommand) => {
+  const convertedCommand = {
+    command:                command.name,
+    enabled:                true,
+    visible:                true,
+    group:                  'nightbot-import',
+    areResponsesRandomized: false,
+    responses:              [
+      {
+        order:          0,
+        response:       command.message,
+        stopIfExecuted: false,
+        permission:     permissions.get(command.userLevel),
+        filter:         '',
+      },
+    ],
+  };
+  try {
+    await axios.post(
+      `${JSON.parse(localStorage.server)}/api/systems/customcommands`,
+      convertedCommand,
+      { headers: { authorization: `Bearer ${getAccessToken()}` } }
+    );
+  } catch (error: any) {
+    console.error(
+      'ERROR DURING COMMANDS IMPORT: ',
+      error.response.data.errors
+    );
+  }
+};
+
+export const importCustomCommands = async (accessToken: string | null) => {
+  const commands = await fetchCustomCommands(accessToken);
+  let failCount = 0;
+  for (const command of commands) {
+    try {
+      command.name.startsWith('!')
+        ? postCommand(command)
+        : postKeyword(command);
+    } catch (error: any) {
+      failCount++;
+    }
+  }
+  if (failCount > 0) {
+    enqueueSnackbar(`${failCount} commands failed to import.`, {
+      variant: 'info',
+    });
+  }
+  enqueueSnackbar('Review imported commands.', { variant: 'info' });
+  enqueueSnackbar('Commands import completed.', { variant: 'success' });
 };

--- a/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
@@ -89,32 +89,31 @@ export const importCustomCommands = async (accessToken: string | null) => {
       await axios.post(
         `${JSON.parse(localStorage.server)}/api/systems/customcommands`,
         {
-          id: command._id,
-          command:
-            '!nb_' + command.name.startsWith('!')
-              ? command.name.substring(1)
-              : command.name,
+          id:                     command._id,
+          command:                command.name,
           enabled:                true,
           visible:                true,
           group:                  'nightbot-import',
           areResponsesRandomized: false,
           responses:              [
             {
-              id:             'nb+' + command._id,
+              id:             command._id,
               order:          0,
               response:       command.message,
               stopIfExecuted: true,
-              permission:     command.userLevel,
-              filter:         '',
-            },
+              permission:     '',
+              filter:         ''
+            }
           ],
         },
         { headers: { authorization: `Bearer ${getAccessToken()}` } }
       );
     } catch (error: any) {
       failCount += 1;
-      console.error('ERROR DURING COMMANDS IMPORT: ', error.response.data.errors);
-      enqueueSnackbar('ERROR DURING COMMANDS IMPORT: ', { variant: 'error' });
+      console.error(
+        'ERROR DURING COMMANDS IMPORT: ',
+        error.response.data.errors
+      );
     }
   }
   if (failCount > 0) {

--- a/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot-utils.ts
@@ -200,7 +200,7 @@ const fetchCustomCommandsPage = async (
   }
 };
 
-export const fetchCustomCommands = async (
+const fetchCustomCommands = async (
   accessToken: string | null
 ): Promise<CustomCommand[]> => {
   try {
@@ -308,7 +308,7 @@ const fetchTimersPage = async (
   }
 };
 
-export const fetchTimers = async (
+const fetchTimers = async (
   accessToken: string | null
 ): Promise<Timer[]> => {
   try {

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -4,7 +4,7 @@ import { useSnackbar } from 'notistack';
 import React, { useEffect } from 'react';
 import { useLocalstorageState, useRefElement } from 'rooks';
 
-import { getSocket } from '../../../helpers/socket';
+import { fetchCustomCommands, importCustomCommands, importPlaylist } from './nightbot-utils';
 import { useAppSelector } from '../../../hooks/useAppDispatch';
 import { useTranslation } from '../../../hooks/useTranslation';
 
@@ -76,219 +76,6 @@ const PageSettingsModulesImportNightbot: React.FC<{
     enqueueSnackbar('User access revoked.', { variant: 'success' });
   }, [enqueueSnackbar]);
 
-  type Command = {
-    providerId: string;
-    provider:   string;
-    duration:   number;
-    title:      string;
-    artist:     string;
-    url:        string;
-  };
-
-  type PlaylistItem = {
-    track:     Command;
-    _id:       string;
-    createdAt: string;
-    updatedAt: string;
-  };
-
-  type PlaylistResponse = {
-    status:   number;
-    _sort:    { date: 'asc' | 'desc' };
-    _limit:   number;
-    _offset:  number;
-    _total:   number;
-    playlist: PlaylistItem[];
-  };
-
-  const sleep = async (ms: number) => {
-    await new Promise((resolve) => setTimeout(resolve, ms));
-  };
-
-  const fetchPlaylistPage = async (
-    offset: number
-  ): Promise<PlaylistResponse> => {
-    const url = 'https://api.nightbot.tv/1/song_requests/playlist';
-    const delay = 10 ** 4 * 6;
-    const delaySeconds = delay / 10 ** 3;
-    for (let retries = 3; retries > 0; retries--) {
-      try {
-        const response = await axios.get(url, {
-          params: {
-            limit:  100,
-            offset: offset,
-          },
-          headers: { Authorization: 'Bearer ' + accessToken },
-        });
-        return response.data;
-      } catch (error: any) {
-        console.info(`Retrying after ${delaySeconds} seconds.`);
-        await sleep(delay);
-      }
-    }
-    console.error('Error fetching playlist page after multiple retries.');
-    enqueueSnackbar('Remote server error.', { variant: 'error' });
-    throw new Error('Failed to fetch playlist after multiple retries.');
-  };
-
-  const fetchTracks = async (
-    tracks: Command[] = [],
-    offset = 0
-  ): Promise<Command[]> => {
-    try {
-      const page = await fetchPlaylistPage(offset);
-      const mergedTracks = tracks.concat(page.playlist.map((t) => t.track));
-      if (mergedTracks.length < page._total) {
-        await fetchTracks(mergedTracks, offset + 100);
-      }
-      return mergedTracks;
-    } catch (error: any) {
-      console.error('Error fetching playlist.');
-      enqueueSnackbar('Remote server error.', { variant: 'error' });
-      throw new Error('Failed to fetch playlist.');
-    }
-  };
-
-  const importPlaylist = async () => {
-    const tracks = await fetchTracks();
-    const ytVideos = tracks.filter((track) => track.provider === 'youtube');
-    let failCount = 0;
-    for (const track of ytVideos) {
-      try {
-        await new Promise((resolve, reject) => {
-          getSocket('/systems/songs').emit(
-            'import.video',
-            {
-              playlist:  track.providerId,
-              forcedTag: 'nightbot-import',
-            },
-            (err) => {
-              if (err) {
-                failCount += 1;
-                console.error('error: ', track.url);
-                reject(err);
-              } else {
-                resolve('resolved');
-              }
-            }
-          );
-        });
-      } catch (error) {
-        console.error('ERROR DURING IMPORT: ', error);
-      }
-    }
-    if (failCount > 0) {
-      enqueueSnackbar(`${failCount} videos failed to import.`, {
-        variant: 'info',
-      });
-    }
-    enqueueSnackbar('Playlist import completed.', { variant: 'success' });
-  };
-
-  type UserLevel =
-    | 'admin'
-    | 'owner'
-    | 'moderator'
-    | 'twitch_vip'
-    | 'regular'
-    | 'subscriber'
-    | 'everyone';
-
-  type CustomCommand = {
-    _id:       string;
-    createdAt: string; // timestamp date
-    updatedAt: string; // timestamp date
-    name:      string;
-    message:   string;
-    coolDown:  number;
-    count:     number;
-    userLevel: UserLevel;
-  };
-
-  type CustomCommandsResponse = {
-    _total:   number;
-    status:   number;
-    commands: CustomCommand[];
-  };
-
-  const fetchWithRetries = async (
-    url: string,
-    headers: { Authorization: string },
-    retries = 3,
-    delay = 6 * 10e4 // 60_000ms
-  ) => {
-    const delaySeconds = delay / 10e3;
-    while (retries-- > 0) {
-      try {
-        const response = await axios.get(url, { headers });
-        return response.data;
-      } catch (error: any) {
-        console.info(`Retrying after ${delaySeconds} seconds.`);
-        await sleep(delay);
-      }
-    }
-  };
-
-  const fetchCustomCommandsPage = async (): Promise<CustomCommandsResponse> => {
-    const url = 'https://api.nightbot.tv/1/commands';
-    try {
-      const page = fetchWithRetries(url, {
-        Authorization: 'Bearer ' + accessToken,
-      });
-      return page;
-    } catch {
-      console.error('Error fetching commands after multiple retries.');
-      enqueueSnackbar('Remote server error.', { variant: 'error' });
-      throw new Error('Failed to fetch commands after multiple retries.');
-    }
-  };
-
-  const fetchCustomCommands = async (): Promise<CustomCommand[]> => {
-    try {
-      const page = await fetchCustomCommandsPage();
-      return page.commands;
-    } catch (error: any) {
-      console.error('Error fetching commands.');
-      enqueueSnackbar('Remote server error.', { variant: 'error' });
-      throw new Error('Failed to fetch commands.');
-    }
-  };
-
-  const importCustomCommands = async () => {
-    const commands = await fetchCustomCommands();
-    let failCount = 0;
-    for (const command of commands) {
-      try {
-        await new Promise((resolve, reject) => {
-          getSocket('/systems/songs').emit(
-            'import.video',
-            {
-              playlist:  command.message,
-              forcedTag: 'nightbot-import',
-            },
-            (err) => {
-              if (err) {
-                failCount += 1;
-                console.error('error: ', command.name);
-                reject(err);
-              } else {
-                resolve('resolved');
-              }
-            }
-          );
-        });
-      } catch (error) {
-        console.error('ERROR DURING IMPORT: ', error);
-      }
-    }
-    if (failCount > 0) {
-      enqueueSnackbar(`${failCount} videos failed to import.`, {
-        variant: 'info',
-      });
-    }
-    enqueueSnackbar('Playlist import completed.', { variant: 'success' });
-  };
-
   return (
     <Box ref={ref} id="nightbot">
       <Typography variant="h2" sx={{ pb: 2 }}>
@@ -305,7 +92,6 @@ const PageSettingsModulesImportNightbot: React.FC<{
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
-                {' '}
                 {user !== 'Not Authorized' ? (
                   <Button color="error" variant="contained" onClick={revoke}>
                     Revoke
@@ -323,12 +109,12 @@ const PageSettingsModulesImportNightbot: React.FC<{
             ),
           }}
         />
-        <Stack direction="row">
+        <Stack direction="row" spacing={1}>
           <Button
             color="primary"
             variant="contained"
             disabled={user === 'Not Authorized'}
-            onClick={importPlaylist}
+            onClick={() => importPlaylist(accessToken)}
           >
             Import playlist
           </Button>
@@ -336,8 +122,8 @@ const PageSettingsModulesImportNightbot: React.FC<{
             color="primary"
             variant="contained"
             disabled={user === 'Not Authorized'}
-            onClick={() => {
-              console.log(fetchCustomCommands());
+            onClick={async () => {
+              console.log(await fetchCustomCommands(accessToken));
               return importCustomCommands;
             }}
           >

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -4,7 +4,7 @@ import { useSnackbar } from 'notistack';
 import React, { useEffect } from 'react';
 import { useLocalstorageState, useRefElement } from 'rooks';
 
-import { fetchCustomCommands, importCustomCommands, importPlaylist } from './nightbot-utils';
+import { importCustomCommands, importPlaylist } from './nightbot-utils';
 import { useAppSelector } from '../../../hooks/useAppDispatch';
 import { useTranslation } from '../../../hooks/useTranslation';
 
@@ -123,8 +123,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
             variant="contained"
             disabled={user === 'Not Authorized'}
             onClick={async () => {
-              console.log(await fetchCustomCommands(accessToken));
-              return importCustomCommands;
+              console.log(await importCustomCommands(accessToken));
             }}
           >
             Import commands

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -109,8 +109,9 @@ const PageSettingsModulesImportNightbot: React.FC<{
             ),
           }}
         />
-        <Stack direction="row" spacing={1}>
+        <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
           <Button
+            fullWidth
             color="primary"
             variant="contained"
             disabled={user === 'Not Authorized'}
@@ -119,6 +120,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
             Import playlist
           </Button>
           <Button
+            fullWidth
             color="primary"
             variant="contained"
             disabled={user === 'Not Authorized'}
@@ -127,6 +129,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
             Import commands
           </Button>
           <Button
+            fullWidth
             color="primary"
             variant="contained"
             disabled={user === 'Not Authorized'}

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -122,9 +122,7 @@ const PageSettingsModulesImportNightbot: React.FC<{
             color="primary"
             variant="contained"
             disabled={user === 'Not Authorized'}
-            onClick={async () => {
-              console.log(await importCustomCommands(accessToken));
-            }}
+            onClick={() => importCustomCommands(accessToken)}
           >
             Import commands
           </Button>

--- a/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
+++ b/ui.admin-mui/src/components/Settings/Import/nightbot.tsx
@@ -4,7 +4,7 @@ import { useSnackbar } from 'notistack';
 import React, { useEffect } from 'react';
 import { useLocalstorageState, useRefElement } from 'rooks';
 
-import { importCustomCommands, importPlaylist } from './nightbot-utils';
+import { importCustomCommands, importPlaylist, importTimers } from './nightbot-utils';
 import { useAppSelector } from '../../../hooks/useAppDispatch';
 import { useTranslation } from '../../../hooks/useTranslation';
 
@@ -125,6 +125,14 @@ const PageSettingsModulesImportNightbot: React.FC<{
             onClick={() => importCustomCommands(accessToken)}
           >
             Import commands
+          </Button>
+          <Button
+            color="primary"
+            variant="contained"
+            disabled={user === 'Not Authorized'}
+            onClick={() => importTimers(accessToken)}
+          >
+            Import timers
           </Button>
         </Stack>
       </Paper>


### PR DESCRIPTION
This is a quick and dirty first pass at fetching a [user's custom commands](https://api-docs.nightbot.tv/#get-custom-commands) from their Nightbot.

I ran `prettier` over the file once to reduce some of the line lengths so I could read the file better. There were a couple of `eslint` warnings that I manually fixed up. Apologies for the whitespace churn in this initial commit!

Meaningful changes begin at L#188, but a lot of this will probably be rewritten after the Nightbot OAuth token includes the `commands` scope. I think that happens [here](https://github.com/sogebot/sogebot.dev/blob/a097fcccda05ecd26bd97a8fde2268a12767c2f1/services/credentials/authenticators/nightbot.go#L28C3-L28C3) but I'm pretty sure I can't test a change to that locally since the oauth callbacks won't work on my localhost.
